### PR TITLE
Config-json fix

### DIFF
--- a/NapiCppWrapper/deps/README
+++ b/NapiCppWrapper/deps/README
@@ -1,3 +1,2 @@
-Copy config.json to 
-  api/wrappers/cpp/win/NapiCpp/NapiCpp , if on Windows
-  directory where your NapiCpp executable is , if on Mac
+Copy config.json to the directory where your NapiCpp executable is. 
+For details, see the Developer Quick Start.

--- a/NapiCppWrapper/deps/config.json
+++ b/NapiCppWrapper/deps/config.json
@@ -1,5 +1,4 @@
 {
   "neaName" : "sampleJS",
-  "sigAlgorithm" : "NIST256P",
-  "automaticFirmwareVersion" : false
+  "sigAlgorithm" : "NIST256P"
 }

--- a/NapiCppWrapper/deps/config.json
+++ b/NapiCppWrapper/deps/config.json
@@ -1,4 +1,4 @@
 {
-  "neaName" : "sampleJS",
+  "neaName" : "NapiCppWrapper",
   "sigAlgorithm" : "NIST256P"
 }

--- a/NapiCppWrapper/osx/NapiCpp/NapiCpp/config.json
+++ b/NapiCppWrapper/osx/NapiCpp/NapiCpp/config.json
@@ -1,5 +1,4 @@
 {
-  "neaName" : "sampleJS",
-  "sigAlgorithm" : "NIST256P",
-  "automaticFirmwareVersion" : false
+  "neaName" : "NapiCppWrapper",
+  "sigAlgorithm" : "NIST256P"
 }

--- a/NapiCppWrapper/win-vs-2015/NapiCpp/NapiCpp/config.json
+++ b/NapiCppWrapper/win-vs-2015/NapiCpp/NapiCpp/config.json
@@ -1,0 +1,4 @@
+{
+  "neaName" : "NapiCppWrapper",
+  "sigAlgorithm" : "NIST256P"
+}


### PR DESCRIPTION
1. Corrected sample app name in config.json.
2. Removed unused reference from config.json.
3. Put a copy of config.json in the folder where the SDK docs say you should find it.
4. Updated readme. 