### PR TITLE
Fixed bug in public key encoding

### DIFF
--- a/Java/RoamingService/src/main/java/com/nymi/sample/roaming/KeyHelper.java
+++ b/Java/RoamingService/src/main/java/com/nymi/sample/roaming/KeyHelper.java
@@ -63,12 +63,15 @@ public class KeyHelper {
 		BigInteger keyX = key.getW().getAffineX();
 		BigInteger keyY = key.getW().getAffineY();
 		
+		System.err.println("Got Affine X of public key: " + keyX);
+		System.err.println("Got Affine Y of public key: " + keyY);
+		
 		byte[] xComponent = toUnsignedByteArray(keyX);
 		byte[] yComponent = toUnsignedByteArray(keyY);
 		
-//		System.err.println("Encoding " + (xComponent.length + yComponent.length) + " byte public key. X size == " + xComponent.length + " and Y size == " + yComponent.length);
-//		System.err.println("Hex encoded X == " + DatatypeConverter.printHexBinary(xComponent));
-//		System.err.println("Hex encoded Y == " + DatatypeConverter.printHexBinary(yComponent));
+		System.err.println("Encoding " + (xComponent.length + yComponent.length) + " byte public key. X size == " + xComponent.length + " and Y size == " + yComponent.length);
+		System.err.println("Hex encoded X == " + DatatypeConverter.printHexBinary(xComponent));
+		System.err.println("Hex encoded Y == " + DatatypeConverter.printHexBinary(yComponent));
 		
 		byte[] complete = new byte[xComponent.length + yComponent.length];
 		System.arraycopy(xComponent, 0, complete, 0, xComponent.length);
@@ -79,10 +82,10 @@ public class KeyHelper {
 
     public static byte[] toUnsignedByteArray(BigInteger value) throws IllegalArgumentException {
         byte[] signedValue = value.toByteArray();
-        if(signedValue[0] != 0x00) {
-            throw new IllegalArgumentException("value must be a positive integer");
-        }
-        return Arrays.copyOfRange(signedValue, 1, signedValue.length);
+        if(signedValue[0] != 0x00)
+        	return Arrays.copyOfRange(signedValue, 0, signedValue.length);
+        else
+        	return Arrays.copyOfRange(signedValue, 1, signedValue.length);
     }
 
 }

--- a/Java/RoamingService/src/main/java/com/nymi/sample/roaming/KeyHelper.java
+++ b/Java/RoamingService/src/main/java/com/nymi/sample/roaming/KeyHelper.java
@@ -63,15 +63,15 @@ public class KeyHelper {
 		BigInteger keyX = key.getW().getAffineX();
 		BigInteger keyY = key.getW().getAffineY();
 		
-		System.err.println("Got Affine X of public key: " + keyX);
-		System.err.println("Got Affine Y of public key: " + keyY);
+		//System.err.println("Got Affine X of public key: " + keyX);
+		//System.err.println("Got Affine Y of public key: " + keyY);
 		
 		byte[] xComponent = toUnsignedByteArray(keyX);
 		byte[] yComponent = toUnsignedByteArray(keyY);
 		
-		System.err.println("Encoding " + (xComponent.length + yComponent.length) + " byte public key. X size == " + xComponent.length + " and Y size == " + yComponent.length);
-		System.err.println("Hex encoded X == " + DatatypeConverter.printHexBinary(xComponent));
-		System.err.println("Hex encoded Y == " + DatatypeConverter.printHexBinary(yComponent));
+		//System.err.println("Encoding " + (xComponent.length + yComponent.length) + " byte public key. X size == " + xComponent.length + " and Y size == " + yComponent.length);
+		//System.err.println("Hex encoded X == " + DatatypeConverter.printHexBinary(xComponent));
+		//System.err.println("Hex encoded Y == " + DatatypeConverter.printHexBinary(yComponent));
 		
 		byte[] complete = new byte[xComponent.length + yComponent.length];
 		System.arraycopy(xComponent, 0, complete, 0, xComponent.length);


### PR DESCRIPTION
Wasn't handling EC key X and Y values with the high bit set (i.e., "negative" numbers).