### PR TITLE
Fix compilation on macOS and crash fix

### DIFF
--- a/Cplusplus/NapiCppWrapper/osx/NapiCpp/NapiCpp.xcodeproj/project.pbxproj
+++ b/Cplusplus/NapiCppWrapper/osx/NapiCpp/NapiCpp.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 				HEADER_SEARCH_PATHS = (
 					../../deps,
 					../../deps/json/src,
+					/Library/Frameworks/napi.framework/Headers,
 				);
 				LIBRARY_SEARCH_PATHS = ../../deps;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -311,6 +312,7 @@
 				HEADER_SEARCH_PATHS = (
 					../../deps,
 					../../deps/json/src,
+					/Library/Frameworks/napi.framework/Headers,
 				);
 				LIBRARY_SEARCH_PATHS = ../../deps;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;

--- a/Cplusplus/NapiCppWrapper/src/Listener.cpp
+++ b/Cplusplus/NapiCppWrapper/src/Listener.cpp
@@ -9,7 +9,7 @@
 #include "Listener.h"
 #include <mutex>
 #include <condition_variable>
-#include <Vector>
+#include <vector>
 #include "napi.h"
 #include "NymiProvision.h"
 #include "TransientNymiBandInfo.h"

--- a/Cplusplus/NapiCppWrapper/src/NymiApi.h
+++ b/Cplusplus/NapiCppWrapper/src/NymiApi.h
@@ -58,7 +58,7 @@ private:
 	ProvisionStorage *storage;  // Provisioning file handler object
 	// Initialization and singleton pattern
 	static NymiApi *nApi;
-	NymiApi() { /*intentionally empty*/ };
+    NymiApi() : storage(nullptr) { /*intentionally empty*/ };
 	NymiApi(NymiApi &dontAllowCopy) { /*intentionally empty*/ }
     NymiApi(NymiApi &&dontAllowMove) { /*intentionally empty*/ }
 


### PR DESCRIPTION
* napi.h could not be found. Adding napi framework headers
* using lowercase for stl library header
* prevent uninitialized pointer access

Tested with xcode 8.3.3

Another option is to include as `<napi/napi.h>`, which is not portable to windows.